### PR TITLE
Convert to Minor Mode, support Customize, prepare for packaging

### DIFF
--- a/save-cwd.el
+++ b/save-cwd.el
@@ -1,12 +1,13 @@
-(defvar save-cwd-location "~/.emacs_cwd"
-  "Location to save the current buffer directory in ")
+(defcustom save-cwd-location "~/.emacs_cwd"
+  "Location to save the current buffer directory in "
+  :type 'file :group 'editing)
 
-(defvar save-cwd-timer-period 5
+(defcustom save-cwd-timer-period 5
   "Number of seconds to wait after being idle to save the current working directory.
 
   The saving process is generally very cheap, so short values (even 1 second) sholud be fine.
-" 
-)
+"
+  :type 'integer :group 'editing)
 
 (defvar *save-cwd-timer-object* nil)
 (defvar *save-cwd-current-directory* nil)

--- a/save-cwd.el
+++ b/save-cwd.el
@@ -8,8 +8,8 @@
 " 
 )
 
-(defvar save-cwd-timer-object nil)
-(defvar save-cwd-current-directory nil)
+(defvar *save-cwd-timer-object* nil)
+(defvar *save-cwd-current-directory* nil)
 
 (defun save-cwd-buffer-directory ()
   (when buffer-file-name
@@ -18,30 +18,31 @@
 (defun save-cwd-save-directory (dirname)
   "Save the current working directory to the file from save-cwd-location"
   (with-temp-file save-cwd-location (insert dirname))
-  (setq save-cwd-current-directory save-cwd-cwd)
-)
+  (setq *save-cwd-current-directory* save-cwd-cwd))
 
 (defun save-cwd-timer ()
   "The meat of the save-cwd effort"
 
   (let ((save-cwd-cwd (save-cwd-buffer-directory)))
-    (when (and save-cwd-cwd (not (equal save-cwd-current-directory save-cwd-cwd)))
-	(save-cwd-save-directory save-cwd-cwd)
-	)))
+    (when (and save-cwd-cwd (not (equal *save-cwd-current-directory* save-cwd-cwd)))
+      (save-cwd-save-directory save-cwd-cwd))))
 
-(defun save-cwd-start ()
-  "Enables saving the current working directory to a file"
-  (interactive)
-  (when (not save-cwd-timer-object)
-    (setq save-cwd-timer-object
-	  (run-with-idle-timer save-cwd-timer-period t 'save-cwd-timer))))
+(defvar save-cwd-mode-p nil)
 
-(defun save-cwd-stop ()
-  "Stops the process of saving the current working directory to a file"
-  (when save-cwd-timer-object
-    (cancel-timer save-cwd-timer-object)
-    (setq save-cwd-timer-object nil)
-    (setq save-cwd-save-directory nil)
-    ))
+(define-minor-mode save-cwd-mode
+  "A mode to save Emacs' Current Working Directory."
+  :lighter " CWD"
+  :global t
+  :variable save-cwd-mode-p
+  (if save-cwd-mode-p
+      (progn
+        (when (not *save-cwd-timer-object*)
+          (setq *save-cwd-timer-object*
+                (run-with-idle-timer save-cwd-timer-period t 'save-cwd-timer))))
+    (progn
+      (when *save-cwd-timer-object*
+        (cancel-timer *save-cwd-timer-object*)
+        (setq *save-cwd-timer-object* nil)
+        (setq *save-cwd-current-directory* nil)))))
 
 (provide 'save-cwd)

--- a/save-cwd.el
+++ b/save-cwd.el
@@ -1,3 +1,18 @@
+;;; save-cwd.el --- Save the Current Working Directory to a file
+
+;; Copyright Goes Here
+
+;; Author: Richard Hardacker <email>
+;; Version: 1.0
+;; Package-Requires: ()
+;; Keywords: convenience
+;; URL: https://github.com/hardaker/elisp-save-cwd
+
+;;; Commentary:
+;; 
+
+;;; Code:
+
 (defcustom save-cwd-location "~/.emacs_cwd"
   "Location to save the current buffer directory in."
   :type 'file :group 'editing)
@@ -17,7 +32,7 @@
     (file-name-directory buffer-file-name)))
 
 (defun save-cwd-save-directory (dirname)
-  "Save the current working directory (DIRNAME) to the file from save-cwd-location."
+  "Save the current working directory (DIRNAME) to the file from ‘save-cwd-location’."
   (with-temp-file save-cwd-location (insert dirname))
   (setq *save-cwd-current-directory* save-cwd-cwd))
 
@@ -46,3 +61,5 @@
         (setq *save-cwd-current-directory* nil)))))
 
 (provide 'save-cwd)
+
+;;; save-cwd.el ends here

--- a/save-cwd.el
+++ b/save-cwd.el
@@ -1,29 +1,28 @@
 (defcustom save-cwd-location "~/.emacs_cwd"
-  "Location to save the current buffer directory in "
+  "Location to save the current buffer directory in."
   :type 'file :group 'editing)
 
 (defcustom save-cwd-timer-period 5
-  "Number of seconds to wait after being idle to save the current working directory.
+  "Wait this many seconds of idle time before saving CWD.
 
-  The saving process is generally very cheap, so short values (even 1 second) sholud be fine.
-"
+  The saving process is generally very cheap, so short values (even 1 second) sholud be fine."
   :type 'integer :group 'editing)
 
 (defvar *save-cwd-timer-object* nil)
 (defvar *save-cwd-current-directory* nil)
 
 (defun save-cwd-buffer-directory ()
+  "Determine the current directory."
   (when buffer-file-name
     (file-name-directory buffer-file-name)))
 
 (defun save-cwd-save-directory (dirname)
-  "Save the current working directory to the file from save-cwd-location"
+  "Save the current working directory (DIRNAME) to the file from save-cwd-location."
   (with-temp-file save-cwd-location (insert dirname))
   (setq *save-cwd-current-directory* save-cwd-cwd))
 
-(defun save-cwd-timer ()
-  "The meat of the save-cwd effort"
-
+(defun save-cwd-timer-function ()
+  "On idle timer, save the cwd."
   (let ((save-cwd-cwd (save-cwd-buffer-directory)))
     (when (and save-cwd-cwd (not (equal *save-cwd-current-directory* save-cwd-cwd)))
       (save-cwd-save-directory save-cwd-cwd))))
@@ -39,7 +38,7 @@
       (progn
         (when (not *save-cwd-timer-object*)
           (setq *save-cwd-timer-object*
-                (run-with-idle-timer save-cwd-timer-period t 'save-cwd-timer))))
+                (run-with-idle-timer save-cwd-timer-period t #'save-cwd-timer-function))))
     (progn
       (when *save-cwd-timer-object*
         (cancel-timer *save-cwd-timer-object*)


### PR DESCRIPTION
These commits define a minor mode, enable customize to set variables and prepare (mostly) the package for submission to MELPA.